### PR TITLE
Remove redundant documentation from on_disk_cache.rs

### DIFF
--- a/src/on_disk_cache.rs
+++ b/src/on_disk_cache.rs
@@ -15,10 +15,6 @@
 //! - A url associated with the package was successfully cloned.
 //! - The clone was performed no more than `refresh_age` days ago.
 //!
-//! A package's entry is considered current if both of the following conditions are met:
-//! - A url associated with the package was successfully cloned.
-//! - The clone was performed no more than `refresh_age` days ago.
-//!
 //! If either of the above conditions are not met, an attempt is made to refresh the entry.
 //!
 //! A similar statement applies to versions.


### PR DESCRIPTION
This PR fixes [#558](https://github.com/trailofbits/cargo-unmaintained/issues/558) by removing redundant documentation from `on_disk_cache.rs` to improve code clarity and maintainability. The changes focus on streamlining the documentation to better reflect the current package entry conditions.

Changes made:
- Removed outdated or redundant documentation
- Improved overall code readability

The changes are purely documentation-related and do not affect the functionality of the code.