### PR TITLE
Standardize cache version reference in purge.rs

### DIFF
--- a/tests/purge.rs
+++ b/tests/purge.rs
@@ -7,7 +7,7 @@ mod tests {
         use std::process::Command;
         use tempfile::tempdir;
 
-        /// The cache version (v2 currently, but could change in the future)
+        // The cache version (v2 currently, but could change in the future)
         const CACHE_VERSION: &str = "v2";
 
         // Create a mock cache directory

--- a/tests/purge.rs
+++ b/tests/purge.rs
@@ -7,9 +7,12 @@ mod tests {
         use std::process::Command;
         use tempfile::tempdir;
 
+        /// The cache version (v2 currently, but could change in the future)
+        const CACHE_VERSION: &str = "v2";
+
         // Create a mock cache directory
         let dir = tempdir().unwrap();
-        let cache_path = dir.path().join("cargo-unmaintained/v2");
+        let cache_path = dir.path().join("cargo-unmaintained").join(CACHE_VERSION);
         create_dir_all(&cache_path).unwrap();
 
         // Create a dummy file inside


### PR DESCRIPTION
### Description
This pull request fixes [#560 ](https://github.com/trailofbits/cargo-unmaintained/issues/560) by standardizing the approach to reference the cache version across test files by introducing a named constant in `tests/purge.rs` that matches the pattern established in `tests/no_cache.rs`.

### Changes
- Added a properly documented constant `CACHE_VERSION: &str = "v2";` in the `test_purge` function
- Refactored the path construction to utilize this constant rather than embedding the version string directly
- Ensured the documentation comment follows the same style as in `no_cache.rs`

### Motivation
Maintaining consistent naming conventions and avoiding hardcoded values across the codebase improves maintainability and reduces the risk of inconsistencies when the cache version needs to be updated in the future.

### Testing
The existing tests continue to function as expected with no behavioral changes.
