### PR TITLE
Add top level documentation to src/lib.rs

### DIFF
--- a/src/bin/cargo-unmaintained.rs
+++ b/src/bin/cargo-unmaintained.rs
@@ -1,3 +1,16 @@
+//! `cargo-unmaintained`
+//!
+//! A tool for finding unmaintained packages in Rust projects.
+//!
+//! `cargo-unmaintained` identifies packages that might be unmaintained by checking:
+//! - Repository activity (last commit age)
+//! - Repository status (e.g., archived, nonexistent)
+//! - Dependency version compatibility (outdated version requirements)
+//!
+//! Detected issues are reported with contextual information and color-coded output.
+//! The tool can be configured to check specific packages, adjust age thresholds,
+//! and control output formatting.
+
 fn main() -> anyhow::Result<()> {
     cargo_unmaintained::run()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,10 @@
+//! Implementation details for `cargo-unmaintained`
+//!
+//! `cargo-unmaintained` is a tool for finding unmaintained packages in Rust
+//! projects.
+//!
+//! The tool's main source file is at `src/bin/cargo-unmaintained.rs`.
+
 #![deny(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
 #![cfg_attr(dylint_lib = "general", allow(crate_wide_allow))]
 #![cfg_attr(dylint_lib = "supplementary", allow(nonexistent_path_in_comment))]


### PR DESCRIPTION
This PR adds file-level documentation to the main library file following Rust's documentation conventions. The added documentation:

- Provides a clear overview of the cargo-unmaintained tool
- Describes the criteria used to identify unmaintained dependencies 
- Highlights key functionality like color-coded output and configuration options

This documentation makes the codebase more accessible to new contributors and follows the pattern established in other files like on_disk_cache.rs.

Fixes #593 
