### PR TITLE
Fix doc comment for environment variables in Test struct

### DIFF
--- a/testing/src/snapbox.rs
+++ b/testing/src/snapbox.rs
@@ -36,7 +36,7 @@ struct Test {
     #[serde(default)]
     use_real_github: bool,
 
-    /// Environment varaibles
+    /// Environment variables
     #[serde(default)]
     env: Vec<(String, String)>,
 }


### PR DESCRIPTION
This pull request corrects a typo in the documentation comment for the `Test` struct. It changes `varaibles` to `variables`. This does not affect the code quality in any way, just improves the clarity and readability of the codebase.