### PR TITLE
Move host filtering earlier (to metadata-fetching stage)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,18 +113,8 @@ pattern = [
 [workspace.metadata.unmaintained]
 ignore = [
     "dashmap",
-    "ff",
-    "foreign-types",
-    "group",
     "lazy_static",
     "rand_chacha",
-    "rand_core",
-    "redox_syscall",
-    "simple_asn1",
-    "smol_str",
-    "spin",
-    "subtle",
     # https://github.com/alacritty/vte/pull/122#issuecomment-2579278540
     "utf8parse",
-    "web-time",
 ]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 <!-- as-of start -->
 
-As of 2026-07-13, the RustSec Advisory Database contains 232 active advisories for unmaintained packages. Using the above conditions, `cargo-unmaintained` automatically identifies 149 (64%) of them. These results can be reproduced by running the [`rustsec_advisories`] example within this repository.
+As of 2026-07-29, the RustSec Advisory Database contains 235 active advisories for unmaintained packages. Using the above conditions, `cargo-unmaintained` automatically identifies 151 (64%) of them. These results can be reproduced by running the [`rustsec_advisories`] example within this repository.
 
 <!-- as-of end -->
 
@@ -34,11 +34,11 @@ As of 2026-07-13, the RustSec Advisory Database contains 232 active advisories f
 
 <!-- not-identified start -->
 
-- Of the 83 packages in the RustSec Advisory Database _not_ identified by `cargo-unmaintained`:
+- Of the 84 packages in the RustSec Advisory Database _not_ identified by `cargo-unmaintained`:
   - 14 do not build
   - 6 are existent, unarchived leaves
-  - 4 were updated within the past 365 days
-  - 59 were not identified for other reasons
+  - 6 were updated within the past 365 days
+  - 58 were not identified for other reasons
 
 <!-- not-identified end -->
 

--- a/ci/src/bin/ci.rs
+++ b/ci/src/bin/ci.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use cargo_metadata::{Message, camino::Utf8PathBuf};
 use elaborate::std::process::CommandContext;
 use std::process::Command;
@@ -17,8 +17,9 @@ fn test_executable() -> Result<Utf8PathBuf> {
     if !output.status.success() {
         bail!("command failed: {command:?}");
     }
-    let messages =
-        Message::parse_stream(output.stdout.as_slice()).collect::<Result<Vec<_>, _>>()?;
+    let messages = Message::parse_stream(output.stdout.as_slice())
+        .collect::<Result<Vec<_>, _>>()
+        .with_context(|| format!("failed to parse metadata from: {command:?}"))?;
     let executables = messages
         .into_iter()
         .filter_map(|message| {

--- a/ci/src/lib.rs
+++ b/ci/src/lib.rs
@@ -31,6 +31,7 @@ fn clippy() {
             "clippy",
             "--all-features",
             "--all-targets",
+            "--workspace",
             "--",
             "--deny=warnings",
         ])
@@ -41,7 +42,14 @@ fn clippy() {
 #[test]
 fn dylint() {
     let assert = Command::new("cargo")
-        .args(["dylint", "--all", "--", "--all-features", "--all-targets"])
+        .args([
+            "dylint",
+            "--all",
+            "--",
+            "--all-features",
+            "--all-targets",
+            "--workspace",
+        ])
         .env("DYLINT_RUSTFLAGS", "--deny warnings")
         .assert();
     let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
@@ -221,6 +229,7 @@ fn readme_contains_expected_contents() {
     assert_eq!(bottom_expected.to_owned() + "\n", bottom_actual);
 }
 
+#[cfg_attr(dylint_lib = "general", allow(non_thread_safe_call_in_test))]
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
 fn readme_contains_usage() {

--- a/ci/supply_chain.json
+++ b/ci/supply_chain.json
@@ -2408,10 +2408,22 @@
     ],
     "jobserver": [
       {
+        "id": 408,
+        "kind": "team",
+        "login": "github:rust-lang:compiler",
+        "name": "compiler"
+      },
+      {
         "id": 1094,
         "kind": "user",
         "login": "petrochenkov",
         "name": "Vadim Petrochenkov"
+      },
+      {
+        "id": 16264,
+        "kind": "team",
+        "login": "github:rust-lang:cargo",
+        "name": "cargo"
       },
       {
         "id": 55123,

--- a/ei/tests/snapbox_real_github.rs
+++ b/ei/tests/snapbox_real_github.rs
@@ -1,9 +1,13 @@
 use elaborate::std::env::set_current_dir_wc;
 
+#[cfg_attr(target_os = "windows", ignore)]
 #[test]
 fn snapbox_real_github() {
     // smoelius: Since there are no other tests in this test executable, changing the current
     // directory is safe.
     set_current_dir_wc("..").unwrap();
-    testing::snapbox::snapbox(true).unwrap();
+    // smoelius: Running with `--all-targets` creates a lot of unfortunate snapbox churn. But for
+    // the packages with which we test, use of the flag seems unavoidable, even when running only on
+    // Linux and macOS.
+    testing::snapbox::snapbox(true, true).unwrap();
 }

--- a/rustsec/tests/rustsec_advisories.rs
+++ b/rustsec/tests/rustsec_advisories.rs
@@ -11,6 +11,7 @@ use std::{
 };
 use testing::{Tee, split_at_cut_lines, split_at_first_cut_line, tee};
 
+#[cfg(test)]
 const PATH_STDOUT: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/tests/rustsec_advisories.stdout"

--- a/rustsec/tests/rustsec_advisories.stdout
+++ b/rustsec/tests/rustsec_advisories.stdout
@@ -1,4 +1,4 @@
-232 advisories for unmaintained packages
+235 advisories for unmaintained packages
 lz4-compress...found
 serial...not found
 tempdir...found
@@ -224,7 +224,7 @@ derivative...found
 openslide...found
 minitrace...found
 mmap...found
-chrono-english...not found
+chrono-english...recently updated
 conrod_core...found
 conrod...found
 gdkwayland...found
@@ -257,7 +257,7 @@ custom_derive...found
 servo-fontconfig...found
 crypto-hash...found
 iron...found
-google-apis-common...not found
+google-apis-common...recently updated
 daemonize...not found
 unic-segment...not found
 unic-char-range...not found
@@ -361,7 +361,10 @@ error: failed to select a version for the requirement `tree-sitter-perl-next = "
 location searched: crates.io index
 required by package `tree-sitter-perl-next-temp-package v0.1.0 ([..])`
 ```
-rustybuzz...not found
+rustybuzz...found
+libcrux-aesgcm...found
+gumdrop...not found
+smallstr...not found
 not found - error (14)
     block-cipher-trait        https://rustsec.org/advisories/RUSTSEC-2020-0018.html
     block-cipher              https://rustsec.org/advisories/RUSTSEC-2020-0057.html
@@ -384,12 +387,14 @@ not found - leaf (6)
     unic-common               https://rustsec.org/advisories/RUSTSEC-2025-0080.html
     number_prefix             https://rustsec.org/advisories/RUSTSEC-2025-0119.html
     bare-metal                https://rustsec.org/advisories/RUSTSEC-2026-0110.html
-not found - recently-updated (4)
+not found - recently-updated (6)
+    chrono-english            https://rustsec.org/advisories/RUSTSEC-2024-0395.html
     tsify-next                https://rustsec.org/advisories/RUSTSEC-2025-0048.html
     async-std                 https://rustsec.org/advisories/RUSTSEC-2025-0052.html
+    google-apis-common        https://rustsec.org/advisories/RUSTSEC-2025-0066.html
     unic-cli                  https://rustsec.org/advisories/RUSTSEC-2025-0087.html
     pqcrypto-internals        https://rustsec.org/advisories/RUSTSEC-2026-0163.html
-not found - other (59)
+not found - other (58)
     serial                    https://rustsec.org/advisories/RUSTSEC-2017-0008.html
     typemap                   https://rustsec.org/advisories/RUSTSEC-2019-0039.html
     stb_truetype              https://rustsec.org/advisories/RUSTSEC-2020-0020.html
@@ -407,10 +412,8 @@ not found - other (59)
     cpython                   https://rustsec.org/advisories/RUSTSEC-2023-0076.html
     yaml-rust                 https://rustsec.org/advisories/RUSTSEC-2024-0320.html
     instant                   https://rustsec.org/advisories/RUSTSEC-2024-0384.html
-    chrono-english            https://rustsec.org/advisories/RUSTSEC-2024-0395.html
     get-size                  https://rustsec.org/advisories/RUSTSEC-2024-0425.html
     fxhash                    https://rustsec.org/advisories/RUSTSEC-2025-0057.html
-    google-apis-common        https://rustsec.org/advisories/RUSTSEC-2025-0066.html
     daemonize                 https://rustsec.org/advisories/RUSTSEC-2025-0069.html
     unic-segment              https://rustsec.org/advisories/RUSTSEC-2025-0074.html
     unic-char-range           https://rustsec.org/advisories/RUSTSEC-2025-0075.html
@@ -448,8 +451,9 @@ not found - other (59)
     pqcrypto-classicmceliece  https://rustsec.org/advisories/RUSTSEC-2026-0167.html
     pqcrypto-hqc              https://rustsec.org/advisories/RUSTSEC-2026-0168.html
     ttf-parser                https://rustsec.org/advisories/RUSTSEC-2026-0192.html
-    rustybuzz                 https://rustsec.org/advisories/RUSTSEC-2026-0206.html
-found (149)
+    gumdrop                   https://rustsec.org/advisories/RUSTSEC-2026-0214.html
+    smallstr                  https://rustsec.org/advisories/RUSTSEC-2026-0215.html
+found (151)
     lz4-compress              https://rustsec.org/advisories/RUSTSEC-2017-0007.html
     tempdir                   https://rustsec.org/advisories/RUSTSEC-2018-0017.html
     boxfnonce                 https://rustsec.org/advisories/RUSTSEC-2019-0040.html
@@ -599,11 +603,13 @@ found (149)
     tide                      https://rustsec.org/advisories/RUSTSEC-2026-0170.html
     proc-macro-error2         https://rustsec.org/advisories/RUSTSEC-2026-0173.html
     cgmath                    https://rustsec.org/advisories/RUSTSEC-2026-0196.html
+    rustybuzz                 https://rustsec.org/advisories/RUSTSEC-2026-0206.html
+    libcrux-aesgcm            https://rustsec.org/advisories/RUSTSEC-2026-0210.html
 ---
-As of 2026-07-13, the RustSec Advisory Database contains 232 active advisories for unmaintained packages. Using the above conditions, `cargo-unmaintained` automatically identifies 149 (64%) of them. These results can be reproduced by running the [`rustsec_advisories`] example within this repository.
+As of 2026-07-29, the RustSec Advisory Database contains 235 active advisories for unmaintained packages. Using the above conditions, `cargo-unmaintained` automatically identifies 151 (64%) of them. These results can be reproduced by running the [`rustsec_advisories`] example within this repository.
 ---
-- Of the 83 packages in the RustSec Advisory Database _not_ identified by `cargo-unmaintained`:
+- Of the 84 packages in the RustSec Advisory Database _not_ identified by `cargo-unmaintained`:
   - 14 do not build
   - 6 are existent, unarchived leaves
-  - 4 were updated within the past 365 days
-  - 59 were not identified for other reasons
+  - 6 were updated within the past 365 days
+  - 58 were not identified for other reasons

--- a/rustsec/tests/rustsec_issues.stdout
+++ b/rustsec/tests/rustsec_issues.stdout
@@ -73,7 +73,7 @@ maligned...not found
 chrono...not found
 toml-rs...not found
 sass-rs...found
-grass...not found
+grass...found
 rsass...not found
 static_type_map...found
 erased_set...not found
@@ -253,8 +253,9 @@ structopt...found
 structopt...found
 ttf-parser...not found
 tree-sitter-perl-next...not found
-rustybuzz...not found
-not found (154)
+rustybuzz...found
+users...not found
+not found (153)
     term                     https://github.com/rustsec/advisory-db/issues/134 
     termcolor                https://github.com/rustsec/advisory-db/issues/173 
     term                     https://github.com/rustsec/advisory-db/issues/173 
@@ -299,7 +300,6 @@ not found (154)
     maligned                 https://github.com/rustsec/advisory-db/issues/1209
     chrono                   https://github.com/rustsec/advisory-db/issues/1216
     toml-rs                  https://github.com/rustsec/advisory-db/issues/1221
-    grass                    https://github.com/rustsec/advisory-db/issues/1228
     rsass                    https://github.com/rustsec/advisory-db/issues/1228
     erased_set               https://github.com/rustsec/advisory-db/issues/1236
     double-checked-cell      https://github.com/rustsec/advisory-db/issues/1239
@@ -408,8 +408,8 @@ not found (154)
     proc-macro-error-2       https://github.com/rustsec/advisory-db/issues/2948
     ttf-parser               https://github.com/rustsec/advisory-db/issues/3011
     tree-sitter-perl-next    https://github.com/rustsec/advisory-db/issues/3039
-    rustybuzz                https://github.com/rustsec/advisory-db/issues/3050
-found (69)
+    users                    https://github.com/rustsec/advisory-db/issues/3066
+found (71)
     chan                     https://github.com/rustsec/advisory-db/issues/173 
     rust-crypto              https://github.com/rustsec/advisory-db/issues/173 
     sodiumoxide              https://github.com/rustsec/advisory-db/issues/173 
@@ -428,6 +428,7 @@ found (69)
     lmdb-rs                  https://github.com/rustsec/advisory-db/issues/1142
     prettytable-rs           https://github.com/rustsec/advisory-db/issues/1173
     sass-rs                  https://github.com/rustsec/advisory-db/issues/1228
+    grass                    https://github.com/rustsec/advisory-db/issues/1228
     static_type_map          https://github.com/rustsec/advisory-db/issues/1236
     wee_alloc                https://github.com/rustsec/advisory-db/issues/1394
     badge                    https://github.com/rustsec/advisory-db/issues/1401
@@ -479,3 +480,4 @@ found (69)
     proc-macro-error2        https://github.com/rustsec/advisory-db/issues/2948
     structopt                https://github.com/rustsec/advisory-db/issues/2975
     structopt                https://github.com/rustsec/advisory-db/issues/2983
+    rustybuzz                https://github.com/rustsec/advisory-db/issues/3050

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,7 +382,7 @@ fn unmaintained() -> Result<bool> {
 }
 
 fn metadata() -> Result<Metadata> {
-    let mut command = MetadataCommand::new();
+    let mut command = metadata_command();
 
     // smoelius: See tests/snapbox.rs for another use of this conditional initialization trick.
     let tempdir: TempDir;
@@ -622,7 +622,7 @@ fn newer_version_is_available(pkg: &Package) -> Result<bool> {
 fn latest_version_is_unmaintained(name: &str) -> Result<bool> {
     let tempdir = packaging::temp_package(name)?;
 
-    let metadata = MetadataCommand::new().current_dir(tempdir.path()).exec()?;
+    let metadata = metadata_command().current_dir(tempdir.path()).exec()?;
 
     #[allow(clippy::panic)]
     let pkg = metadata
@@ -635,6 +635,29 @@ fn latest_version_is_unmaintained(name: &str) -> Result<bool> {
 
     Ok(unmaintained_package.is_some())
 }
+
+fn metadata_command() -> MetadataCommand {
+    let mut command = MetadataCommand::new();
+    // smoelius: Note that `other_options` replaces previous options; it does not add to them. So if
+    // additional options are needed, they must be added here.
+    if !opts::get().all_targets {
+        command.other_options(["--filter-platform".to_owned(), HOST.clone()]);
+    }
+    command
+}
+
+#[allow(clippy::panic, clippy::unwrap_used)]
+static HOST: LazyLock<String> = LazyLock::new(|| {
+    let mut command = Command::new("rustc");
+    command.arg("-Vv");
+    let output = command.output_wc().unwrap();
+    assert!(output.status.success(), "command failed: {command:?}");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("host: "))
+        .map_or_else(|| panic!("failed to determine host"), str::to_owned)
+});
 
 fn is_unmaintained_package<'a>(
     metadata: &'a Metadata,
@@ -735,19 +758,6 @@ fn general_status(name: &str, url: Url) -> Result<RepoStatus<'static, ()>> {
     })
 }
 
-#[allow(clippy::panic, clippy::unwrap_used)]
-static HOST: LazyLock<String> = LazyLock::new(|| {
-    let mut command = Command::new("rustc");
-    command.arg("-Vv");
-    let output = command.output_wc().unwrap();
-    assert!(output.status.success(), "command failed: {command:?}");
-    let stdout = String::from_utf8(output.stdout).unwrap();
-    stdout
-        .lines()
-        .find_map(|line| line.strip_prefix("host: "))
-        .map_or_else(|| panic!("failed to determine host"), str::to_owned)
-});
-
 #[allow(clippy::unnecessary_wraps)]
 fn outdated_deps<'a>(metadata: &'a Metadata, pkg: &'a Package) -> Result<Vec<OutdatedDep<'a>>> {
     if !published(pkg) {
@@ -755,13 +765,6 @@ fn outdated_deps<'a>(metadata: &'a Metadata, pkg: &'a Package) -> Result<Vec<Out
     }
     let mut deps = Vec::new();
     for dep in &pkg.dependencies {
-        // smoelius: Skip dependencies with specified platforms that are not the host.
-        if !opts::get().all_targets
-            && let Some(platform) = &dep.target
-            && !platform.matches(&HOST, &[])
-        {
-            continue;
-        }
         // smoelius: Don't check dependencies in private registries.
         if dep.registry.is_some() {
             continue;
@@ -774,7 +777,14 @@ fn outdated_deps<'a>(metadata: &'a Metadata, pkg: &'a Package) -> Result<Vec<Out
             continue;
         }
         let Some(dep_pkg) = resolved_package(metadata, pkg, dep) else {
-            debug_assert!(dep.optional);
+            // smoelius: An unresolved dependency must either be optional and disabled or have been
+            // excluded by `--filter-platform`. Note that this assertion does not flag
+            // platform-gated dependencies that apply to the host but fail to resolve. Flagging
+            // those would require the host's `cfg`s and use of, e.g., `Platform::matches`.
+            debug_assert!(
+                dep.optional || (!opts::get().all_targets && dep.target.is_some()),
+                "failed for: {dep:?}"
+            );
             continue;
         };
         let Ok(version_latest) = latest_version(&dep.name).map_err(|error| {
@@ -1194,7 +1204,13 @@ fn display_unmaintained_pkg(unmaintained_pkg: &UnmaintainedPkg) -> Result<bool> 
 fn display_path(name: &str, version: &Version) -> Result<bool> {
     let spec = format!("{name}@{version}");
     let mut command = Command::new("cargo");
-    command.args(["tree", "--workspace", "--target=all", "--invert", &spec]);
+    command.args(["tree", "--workspace"]);
+    if opts::get().all_targets {
+        command.arg("--target=all");
+    } else {
+        command.args(["--target", HOST.as_str()]);
+    }
+    command.args(["--invert", &spec]);
     let output = command.output_wc()?;
     // smoelius: Hack. It appears that `cargo tree` does not print proc-macros used by proc-macros.
     // For now, check whether stdout begins as expected. If not, ignore it and ultimately emit a

--- a/testing/src/snapbox.rs
+++ b/testing/src/snapbox.rs
@@ -48,7 +48,7 @@ struct Test {
 
 #[allow(clippy::too_many_lines)]
 #[cfg_attr(dylint_lib = "supplementary", allow(commented_out_code))]
-pub fn snapbox(real_github: bool) -> Result<()> {
+pub fn snapbox(real_github: bool, all_targets: bool) -> Result<()> {
     // #[cfg(not(feature = "lock-index"))]
     // panic!("the `snapbox` test requires the `lock-index` feature");
 
@@ -152,6 +152,9 @@ pub fn snapbox(real_github: bool) -> Result<()> {
             ]);
         }
         command.args(["--", "unmaintained", "--color=never", "--json"]);
+        if all_targets {
+            command.arg("--all-targets");
+        }
         command.args(test.args);
         command.envs(test.env);
         if let Some(dir) = dir {

--- a/tests/cases/cargo.json
+++ b/tests/cases/cargo.json
@@ -205,5 +205,53 @@
     "outdated_deps": [],
     "repo_status": "Unassociated",
     "version": "0.2.89"
+  },
+  {
+    "name": "windows-targets",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.52.0"
+  },
+  {
+    "name": "windows_aarch64_gnullvm",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.52.0"
+  },
+  {
+    "name": "windows_aarch64_msvc",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.52.0"
+  },
+  {
+    "name": "windows_i686_gnu",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.52.0"
+  },
+  {
+    "name": "windows_i686_msvc",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.52.0"
+  },
+  {
+    "name": "windows_x86_64_gnu",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.52.0"
+  },
+  {
+    "name": "windows_x86_64_gnullvm",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.52.0"
+  },
+  {
+    "name": "windows_x86_64_msvc",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.52.0"
   }
 ]

--- a/tests/cases/dev-dependencies-resolvable.stderr
+++ b/tests/cases/dev-dependencies-resolvable.stderr
@@ -1,2 +1,2 @@
-Prefetching GitHub data for 15 repositories
-Scanning 20 packages and their dependencies (pass --verbose for more information)
+Prefetching GitHub data for 10 repositories
+Scanning 14 packages and their dependencies (pass --verbose for more information)

--- a/tests/cases/hyperfine.json
+++ b/tests/cases/hyperfine.json
@@ -1,5 +1,20 @@
 [
   {
+    "name": "atty",
+    "outdated_deps": [
+      {
+        "name": "hermit-abi",
+        "req": "^0.1.6",
+        "version_latest": null,
+        "version_used": "0.1.19"
+      }
+    ],
+    "repo_status": {
+      "Age": null
+    },
+    "version": "0.2.14"
+  },
+  {
     "name": "bitvec",
     "outdated_deps": [
       {
@@ -91,5 +106,53 @@
     "outdated_deps": [],
     "repo_status": "Unassociated",
     "version": "0.2.1"
+  },
+  {
+    "name": "windows-targets",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.48.5"
+  },
+  {
+    "name": "windows_aarch64_gnullvm",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.48.5"
+  },
+  {
+    "name": "windows_aarch64_msvc",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.48.5"
+  },
+  {
+    "name": "windows_i686_gnu",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.48.5"
+  },
+  {
+    "name": "windows_i686_msvc",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.48.5"
+  },
+  {
+    "name": "windows_x86_64_gnu",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.48.5"
+  },
+  {
+    "name": "windows_x86_64_gnullvm",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.48.5"
+  },
+  {
+    "name": "windows_x86_64_msvc",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.48.5"
   }
 ]

--- a/tests/cases/old-repository-non-member.stderr
+++ b/tests/cases/old-repository-non-member.stderr
@@ -1,5 +1,5 @@
-Prefetching GitHub data for 2 repositories
-Scanning 5 packages and their dependencies (pass --verbose for more information)
+Prefetching GitHub data for 1 repositories
+Scanning 2 packages and their dependencies (pass --verbose for more information)
 warning: failed to clone `https://codeberg.org/flausch/gethostname.rs.git`: [
     "[..]remote: Credentials are incorrect or have expired. Retry your command or see https://codeberg.org/forgejo/forgejo/issues/2809 for more information/nfatal: Authentication failed for 'https://codeberg.org/Greebling/gethostname.rs.git/'/n",
 ...

--- a/tests/cases/optional-dependencies-resolvable.stderr
+++ b/tests/cases/optional-dependencies-resolvable.stderr
@@ -1,2 +1,2 @@
-Prefetching GitHub data for 18 repositories
-Scanning 24 packages and their dependencies (pass --verbose for more information)
+Prefetching GitHub data for 13 repositories
+Scanning 17 packages and their dependencies (pass --verbose for more information)

--- a/tests/cases/optional-dependencies-unresolvable.stderr
+++ b/tests/cases/optional-dependencies-unresolvable.stderr
@@ -1,2 +1,2 @@
-Prefetching GitHub data for 11 repositories
-Scanning 14 packages and their dependencies (pass --verbose for more information)
+Prefetching GitHub data for 7 repositories
+Scanning 9 packages and their dependencies (pass --verbose for more information)

--- a/tests/cases/pretty_yaml.json
+++ b/tests/cases/pretty_yaml.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "name": "rowan",
+    "outdated_deps": [
+      {
+        "name": "hashbrown",
+        "req": "^0.14.3",
+        "version_latest": null,
+        "version_used": "0.14.5"
+      },
+      {
+        "name": "rustc-hash",
+        "req": "^1.0.1",
+        "version_latest": null,
+        "version_used": "1.1.0"
+      }
+    ],
+    "repo_status": {
+      "Age": null
+    },
+    "version": "0.15.16"
+  }
+]

--- a/tests/cases/pretty_yaml.stderr
+++ b/tests/cases/pretty_yaml.stderr
@@ -1,2 +1,2 @@
-Prefetching GitHub data for 39 repositories
-Scanning 53 packages and their dependencies (pass --verbose for more information)
+Prefetching GitHub data for 36 repositories
+Scanning 41 packages and their dependencies (pass --verbose for more information)

--- a/tests/cases/taplo.json
+++ b/tests/cases/taplo.json
@@ -6,6 +6,21 @@
     "version": "1.0.2"
   },
   {
+    "name": "atty",
+    "outdated_deps": [
+      {
+        "name": "hermit-abi",
+        "req": "^0.1.6",
+        "version_latest": null,
+        "version_used": "0.1.19"
+      }
+    ],
+    "repo_status": {
+      "Age": null
+    },
+    "version": "0.2.14"
+  },
+  {
     "name": "bit-set",
     "outdated_deps": [],
     "repo_status": "Unassociated",
@@ -87,6 +102,33 @@
     "version": "1.0.4"
   },
   {
+    "name": "rowan",
+    "outdated_deps": [
+      {
+        "name": "hashbrown",
+        "req": "^0.12",
+        "version_latest": null,
+        "version_used": "0.12.3"
+      },
+      {
+        "name": "memoffset",
+        "req": "^0.6",
+        "version_latest": null,
+        "version_used": "0.6.5"
+      },
+      {
+        "name": "rustc-hash",
+        "req": "^1.0.1",
+        "version_latest": null,
+        "version_used": "1.1.0"
+      }
+    ],
+    "repo_status": {
+      "Age": null
+    },
+    "version": "0.15.10"
+  },
+  {
     "name": "rustls-pemfile",
     "outdated_deps": [],
     "repo_status": "Archived",
@@ -151,5 +193,47 @@
     "outdated_deps": [],
     "repo_status": "Unassociated",
     "version": "0.2.83"
+  },
+  {
+    "name": "windows_aarch64_gnullvm",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.42.0"
+  },
+  {
+    "name": "windows_aarch64_msvc",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.42.0"
+  },
+  {
+    "name": "windows_i686_gnu",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.42.0"
+  },
+  {
+    "name": "windows_i686_msvc",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.42.0"
+  },
+  {
+    "name": "windows_x86_64_gnu",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.42.0"
+  },
+  {
+    "name": "windows_x86_64_gnullvm",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.42.0"
+  },
+  {
+    "name": "windows_x86_64_msvc",
+    "outdated_deps": [],
+    "repo_status": "Unassociated",
+    "version": "0.42.0"
   }
 ]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -82,11 +82,9 @@ ignore = ["{name}"]
     Ok(())
 }
 
+#[cfg(test)]
 fn cargo_unmaintained(dir: &Path) -> Command {
-    #[cfg_attr(
-        dylint_lib = "general",
-        allow(abs_home_path, unnecessary_conversion_for_trait)
-    )]
+    #[cfg_attr(dylint_lib = "general", allow(unnecessary_conversion_for_trait))]
     // smoelius: `Command::new(cargo_bin!(..))` because this function's return type is
     // `std::process::Command`, not `assert_cmd::Command`.
     let mut command = Command::new(cargo::cargo_bin!("cargo-unmaintained"));

--- a/tests/snapbox.rs
+++ b/tests/snapbox.rs
@@ -1,4 +1,5 @@
+#[cfg_attr(target_os = "windows", ignore)]
 #[test]
 fn snapbox() {
-    testing::snapbox::snapbox(false).unwrap();
+    testing::snapbox::snapbox(false, false).unwrap();
 }


### PR DESCRIPTION
The third-party `snapbox` tests still need to be updated, but SourceHut is experiencing problems.