### PR TITLE
Enable `non_topologically_sorted_functions` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ pattern = [
     "examples/restriction/assert_eq_arg_misordering",
     "examples/restriction/inconsistent_qualification",
     "examples/restriction/misleading_variable_name",
+    "examples/restriction/non_topologically_sorted_functions",
     "examples/restriction/suboptimal_pattern",
     "examples/restriction/try_io_result",
 ]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 <!-- as-of start -->
 
-As of 2026-08-12, the RustSec Advisory Database contains 244 active advisories for unmaintained packages. Using the above conditions, `cargo-unmaintained` automatically identifies 160 (65%) of them. These results can be reproduced by running the [`rustsec_advisories`] example within this repository.
+As of 2026-08-17, the RustSec Advisory Database contains 244 active advisories for unmaintained packages. Using the above conditions, `cargo-unmaintained` automatically identifies 150 (61%) of them. These results can be reproduced by running the [`rustsec_advisories`] example within this repository.
 
 <!-- as-of end -->
 
@@ -34,10 +34,10 @@ As of 2026-08-12, the RustSec Advisory Database contains 244 active advisories f
 
 <!-- not-identified start -->
 
-- Of the 84 packages in the RustSec Advisory Database _not_ identified by `cargo-unmaintained`:
+- Of the 94 packages in the RustSec Advisory Database _not_ identified by `cargo-unmaintained`:
   - 14 do not build
   - 6 are existent, unarchived leaves
-  - 6 were updated within the past 365 days
+  - 16 were updated within the past 365 days
   - 58 were not identified for other reasons
 
 <!-- not-identified end -->

--- a/examples/rustsec_advisories.rs
+++ b/examples/rustsec_advisories.rs
@@ -144,18 +144,30 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-macro_rules! count {
-    ($outcomes:expr, $pat:pat) => {
-        $outcomes
-            .iter()
-            .filter(|outcome| matches!(outcome, $pat))
-            .count()
-    };
+fn is_leaf(name: &str, path: &Path) -> Result<bool> {
+    let metadata = MetadataCommand::new().current_dir(path).exec()?;
+    Ok(metadata.packages.iter().all(|pkg| {
+        pkg.name == format!("{name}-temp-package")
+            || pkg.dependencies.iter().all(|dep| dep.path.is_some())
+    }))
 }
 
-const CUT_LINE: &str = "---";
+fn advisory_url(advisory: &Advisory) -> String {
+    format!("https://rustsec.org/advisories/{}.html", advisory.id())
+}
 
 fn display_expected_readme_contents(outcomes: &[Outcome<Reason>]) {
+    macro_rules! count {
+        ($outcomes:expr, $pat:pat) => {
+            $outcomes
+                .iter()
+                .filter(|outcome| matches!(outcome, $pat))
+                .count()
+        };
+    }
+
+    const CUT_LINE: &str = "---";
+
     let today = Utc::now().date_naive();
     let count = outcomes.len();
     let found = count!(outcomes, Outcome::Found);
@@ -182,18 +194,6 @@ fn display_expected_readme_contents(outcomes: &[Outcome<Reason>]) {
     println!("  - {leaf} are existent, unarchived leaves");
     println!("  - {recently_updated} were updated within the past 365 days");
     println!("  - {other} were not identified for other reasons");
-}
-
-fn advisory_url(advisory: &Advisory) -> String {
-    format!("https://rustsec.org/advisories/{}.html", advisory.id())
-}
-
-fn is_leaf(name: &str, path: &Path) -> Result<bool> {
-    let metadata = MetadataCommand::new().current_dir(path).exec()?;
-    Ok(metadata.packages.iter().all(|pkg| {
-        pkg.name == format!("{name}-temp-package")
-            || pkg.dependencies.iter().all(|dep| dep.path.is_some())
-    }))
 }
 
 trait Sanitize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -924,7 +924,6 @@ fn general_status(name: &str, url: Url) -> Result<RepoStatus<'static, ()>> {
     })
 }
 
-#[allow(clippy::unnecessary_wraps)]
 fn outdated_deps<'a>(metadata: &'a Metadata, pkg: &'a Package) -> Result<Vec<OutdatedDep<'a>>> {
     if !published(pkg) {
         return Ok(Vec::new());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -620,20 +620,6 @@ fn cache_prefetched_github_data(repo_status: RepoStatus<'_, SystemTime>, url: Ur
     }
 }
 
-fn newer_version_is_available(pkg: &Package) -> Result<bool> {
-    if pkg
-        .source
-        .as_ref()
-        .is_none_or(|source| !source.is_crates_io())
-    {
-        return Ok(false);
-    }
-
-    let latest_version = latest_version(&pkg.name)?;
-
-    Ok(pkg.version != latest_version)
-}
-
 fn latest_version_is_unmaintained(name: &str) -> Result<bool> {
     let tempdir = packaging::temp_package(name)?;
 
@@ -732,6 +718,171 @@ fn is_unmaintained_package<'a>(
         newer_version_is_available: false,
         outdated_deps,
     }))
+}
+
+fn newer_version_is_available(pkg: &Package) -> Result<bool> {
+    if pkg
+        .source
+        .as_ref()
+        .is_none_or(|source| !source.is_crates_io())
+    {
+        return Ok(false);
+    }
+
+    let latest_version = latest_version(&pkg.name)?;
+
+    Ok(pkg.version != latest_version)
+}
+
+fn latest_commit_age(pkg: &Package) -> Result<RepoStatus<'_, u64>> {
+    let repo_status = timestamp(pkg)?;
+
+    repo_status
+        .map(|timestamp| {
+            let duration = SystemTime::now().duration_since_wc(timestamp)?;
+
+            Ok(duration.as_secs())
+        })
+        .transpose()
+}
+
+fn timestamp(pkg: &Package) -> Result<RepoStatus<'_, SystemTime>> {
+    TIMESTAMP_CACHE.with_borrow_mut(|timestamp_cache| {
+        // smoelius: Check both the regular and the shortened url.
+        for url in urls(pkg) {
+            if let Some(&repo_status) = timestamp_cache.get(&url) {
+                // smoelius: If a previous attempt to timestamp the repository failed (e.g., because
+                // of spurious network errors), then don't bother checking the repository cache.
+                let Some((url_timestamped, &timestamp)) = repo_status.as_success() else {
+                    return Ok(repo_status);
+                };
+                assert_eq!(url, url_timestamped);
+                // smoelius: `pkg`'s repository could contain other packages that were already
+                // timestamped. Thus, `pkg`'s repository could already be in the timestamp cache.
+                // But in that case, we still need to verify that `pkg` appears in its repository.
+                let repo_status = clone_repository(pkg)?;
+                let Some((url_cloned, _)) = repo_status.as_success() else {
+                    return Ok(repo_status.map_failure());
+                };
+                assert_eq!(url, url_cloned);
+                return Ok(RepoStatus::Success(url, timestamp));
+            }
+        }
+        let repo_status = timestamp_uncached(pkg)?;
+        if let Some((url, _)) = repo_status.as_success() {
+            timestamp_cache.insert(url.leak(), repo_status.leak_url());
+        } else {
+            // smoelius: In the event of failure, set all urls associated with the
+            // repository.
+            for url in urls(pkg) {
+                timestamp_cache.insert(url.leak(), repo_status.leak_url());
+            }
+        }
+        Ok(repo_status)
+    })
+}
+
+fn timestamp_uncached(pkg: &Package) -> Result<RepoStatus<'_, SystemTime>> {
+    if pkg.repository.is_none() {
+        return Ok(RepoStatus::Unnamed);
+    }
+
+    timestamp_from_clone(pkg)
+}
+
+fn timestamp_from_clone(pkg: &Package) -> Result<RepoStatus<'_, SystemTime>> {
+    let repo_status = clone_repository(pkg)?;
+
+    let Some((url, repo_dir)) = repo_status.as_success() else {
+        return Ok(repo_status.map_failure());
+    };
+
+    let mut command = Command::new("git");
+    command
+        .args(["log", "-1", "--pretty=format:%ct"])
+        .current_dir(repo_dir);
+    let output = command.output_wc()?;
+    ensure!(output.status.success(), "command failed: {command:?}");
+
+    let stdout = std::str::from_utf8(&output.stdout)?;
+    let secs = u64::from_str(stdout.trim_end())?;
+    let timestamp = SystemTime::UNIX_EPOCH + Duration::from_secs(secs);
+
+    Ok(RepoStatus::Success(url, timestamp))
+}
+
+#[cfg_attr(dylint_lib = "general", allow(non_local_effect_before_unhandled_error))]
+#[cfg_attr(dylint_lib = "supplementary", allow(commented_out_code))]
+fn clone_repository(pkg: &Package) -> Result<RepoStatus<'_, PathBuf>> {
+    let repo_status = REPOSITORY_CACHE.with_borrow_mut(|repository_cache| -> Result<_> {
+        on_disk_cache::with_cache(|cache| -> Result<_> {
+            // smoelius: Check all urls associated with the package.
+            for url in urls(pkg) {
+                if let Some(repo_status) = repository_cache.get(&url) {
+                    return Ok(repo_status.clone());
+                }
+            }
+            // smoelius: To make verbose printing easier, "membership" is printed regardless of the
+            // check's purpose, and the `Purpose` type was removed.
+            /* let what = match purpose {
+                Purpose::Membership => "membership",
+                Purpose::Timestamp => "timestamp",
+            }; */
+            verbose::wrap!(
+                || {
+                    let url_and_dir = cache.clone_repository(pkg);
+                    match url_and_dir {
+                        Ok((url_string, repo_dir)) => {
+                            // smoelius: Note the use of `leak` in the next line. But the url is
+                            // acting as a key in a global map, so it is not so bad.
+                            let url = Url::from(url_string.as_str()).leak();
+                            repository_cache
+                                .insert(url, RepoStatus::Success(url, repo_dir.clone()).leak_url());
+                            Ok(RepoStatus::Success(url, repo_dir))
+                        }
+                        Err(error) => {
+                            let repo_status = if let Some(url_string) = &pkg.repository {
+                                let url = url_string.as_str().into();
+                                // smoelius: If cloning failed because the repository does not
+                                // exist, adjust the repo status.
+                                let existence = general_status(&pkg.name, url)?;
+                                let repo_status = if existence.is_failure() {
+                                    existence.map_failure()
+                                } else {
+                                    RepoStatus::Uncloneable(url)
+                                };
+                                warn!("failed to clone `{}`: {}", url_string, error);
+                                repo_status
+                            } else {
+                                RepoStatus::Unnamed
+                            };
+                            // smoelius: In the event of failure, set all urls associated with
+                            // the repository.
+                            for url in urls(pkg) {
+                                repository_cache.insert(url.leak(), repo_status.clone().leak_url());
+                            }
+                            Ok(repo_status)
+                        }
+                    }
+                },
+                RepoStatus::to_membership_string,
+                "membership of `{}` using shallow clone",
+                pkg.name
+            )
+        })
+    })?;
+
+    let Some((url, repo_dir)) = repo_status.as_success() else {
+        return Ok(repo_status);
+    };
+
+    // smoelius: Even if `purpose` is `Purpose::Timestamp`, verify that `pkg` is a member of the
+    // repository.
+    if membership_in_clone(pkg, repo_dir)? {
+        Ok(repo_status)
+    } else {
+        Ok(RepoStatus::Unassociated(url))
+    }
 }
 
 fn general_status(name: &str, url: Url) -> Result<RepoStatus<'static, ()>> {
@@ -930,157 +1081,6 @@ fn versions(name: &str) -> Result<Vec<crates_io_api::Version>> {
             name
         )
     })
-}
-
-fn latest_commit_age(pkg: &Package) -> Result<RepoStatus<'_, u64>> {
-    let repo_status = timestamp(pkg)?;
-
-    repo_status
-        .map(|timestamp| {
-            let duration = SystemTime::now().duration_since_wc(timestamp)?;
-
-            Ok(duration.as_secs())
-        })
-        .transpose()
-}
-
-fn timestamp(pkg: &Package) -> Result<RepoStatus<'_, SystemTime>> {
-    TIMESTAMP_CACHE.with_borrow_mut(|timestamp_cache| {
-        // smoelius: Check both the regular and the shortened url.
-        for url in urls(pkg) {
-            if let Some(&repo_status) = timestamp_cache.get(&url) {
-                // smoelius: If a previous attempt to timestamp the repository failed (e.g., because
-                // of spurious network errors), then don't bother checking the repository cache.
-                let Some((url_timestamped, &timestamp)) = repo_status.as_success() else {
-                    return Ok(repo_status);
-                };
-                assert_eq!(url, url_timestamped);
-                // smoelius: `pkg`'s repository could contain other packages that were already
-                // timestamped. Thus, `pkg`'s repository could already be in the timestamp cache.
-                // But in that case, we still need to verify that `pkg` appears in its repository.
-                let repo_status = clone_repository(pkg)?;
-                let Some((url_cloned, _)) = repo_status.as_success() else {
-                    return Ok(repo_status.map_failure());
-                };
-                assert_eq!(url, url_cloned);
-                return Ok(RepoStatus::Success(url, timestamp));
-            }
-        }
-        let repo_status = timestamp_uncached(pkg)?;
-        if let Some((url, _)) = repo_status.as_success() {
-            timestamp_cache.insert(url.leak(), repo_status.leak_url());
-        } else {
-            // smoelius: In the event of failure, set all urls associated with the
-            // repository.
-            for url in urls(pkg) {
-                timestamp_cache.insert(url.leak(), repo_status.leak_url());
-            }
-        }
-        Ok(repo_status)
-    })
-}
-
-fn timestamp_uncached(pkg: &Package) -> Result<RepoStatus<'_, SystemTime>> {
-    if pkg.repository.is_none() {
-        return Ok(RepoStatus::Unnamed);
-    }
-
-    timestamp_from_clone(pkg)
-}
-
-fn timestamp_from_clone(pkg: &Package) -> Result<RepoStatus<'_, SystemTime>> {
-    let repo_status = clone_repository(pkg)?;
-
-    let Some((url, repo_dir)) = repo_status.as_success() else {
-        return Ok(repo_status.map_failure());
-    };
-
-    let mut command = Command::new("git");
-    command
-        .args(["log", "-1", "--pretty=format:%ct"])
-        .current_dir(repo_dir);
-    let output = command.output_wc()?;
-    ensure!(output.status.success(), "command failed: {command:?}");
-
-    let stdout = std::str::from_utf8(&output.stdout)?;
-    let secs = u64::from_str(stdout.trim_end())?;
-    let timestamp = SystemTime::UNIX_EPOCH + Duration::from_secs(secs);
-
-    Ok(RepoStatus::Success(url, timestamp))
-}
-
-#[cfg_attr(dylint_lib = "general", allow(non_local_effect_before_unhandled_error))]
-#[cfg_attr(dylint_lib = "supplementary", allow(commented_out_code))]
-fn clone_repository(pkg: &Package) -> Result<RepoStatus<'_, PathBuf>> {
-    let repo_status = REPOSITORY_CACHE.with_borrow_mut(|repository_cache| -> Result<_> {
-        on_disk_cache::with_cache(|cache| -> Result<_> {
-            // smoelius: Check all urls associated with the package.
-            for url in urls(pkg) {
-                if let Some(repo_status) = repository_cache.get(&url) {
-                    return Ok(repo_status.clone());
-                }
-            }
-            // smoelius: To make verbose printing easier, "membership" is printed regardless of the
-            // check's purpose, and the `Purpose` type was removed.
-            /* let what = match purpose {
-                Purpose::Membership => "membership",
-                Purpose::Timestamp => "timestamp",
-            }; */
-            verbose::wrap!(
-                || {
-                    let url_and_dir = cache.clone_repository(pkg);
-                    match url_and_dir {
-                        Ok((url_string, repo_dir)) => {
-                            // smoelius: Note the use of `leak` in the next line. But the url is
-                            // acting as a key in a global map, so it is not so bad.
-                            let url = Url::from(url_string.as_str()).leak();
-                            repository_cache
-                                .insert(url, RepoStatus::Success(url, repo_dir.clone()).leak_url());
-                            Ok(RepoStatus::Success(url, repo_dir))
-                        }
-                        Err(error) => {
-                            let repo_status = if let Some(url_string) = &pkg.repository {
-                                let url = url_string.as_str().into();
-                                // smoelius: If cloning failed because the repository does not
-                                // exist, adjust the repo status.
-                                let existence = general_status(&pkg.name, url)?;
-                                let repo_status = if existence.is_failure() {
-                                    existence.map_failure()
-                                } else {
-                                    RepoStatus::Uncloneable(url)
-                                };
-                                warn!("failed to clone `{}`: {}", url_string, error);
-                                repo_status
-                            } else {
-                                RepoStatus::Unnamed
-                            };
-                            // smoelius: In the event of failure, set all urls associated with
-                            // the repository.
-                            for url in urls(pkg) {
-                                repository_cache.insert(url.leak(), repo_status.clone().leak_url());
-                            }
-                            Ok(repo_status)
-                        }
-                    }
-                },
-                RepoStatus::to_membership_string,
-                "membership of `{}` using shallow clone",
-                pkg.name
-            )
-        })
-    })?;
-
-    let Some((url, repo_dir)) = repo_status.as_success() else {
-        return Ok(repo_status);
-    };
-
-    // smoelius: Even if `purpose` is `Purpose::Timestamp`, verify that `pkg` is a member of the
-    // repository.
-    if membership_in_clone(pkg, repo_dir)? {
-        Ok(repo_status)
-    } else {
-        Ok(RepoStatus::Unassociated(url))
-    }
 }
 
 const LINE_PREFIX: &str = "D  ";

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -68,6 +68,18 @@ fn add_dependency(dir: &Path, name: &str) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
+fn cargo_unmaintained(dir: &Path) -> Command {
+    #[cfg_attr(dylint_lib = "general", allow(unnecessary_conversion_for_trait))]
+    // smoelius: `Command::new(cargo_bin!(..))` because this function's return type is
+    // `std::process::Command`, not `assert_cmd::Command`.
+    let mut command = Command::new(cargo::cargo_bin!("cargo-unmaintained"));
+    command
+        .args(["unmaintained", "--fail-fast"])
+        .current_dir(dir);
+    command
+}
+
 fn ignore_package(dir: &Path, name: &str) -> Result<()> {
     let mut manifest = OpenOptions::new()
         .append(true)
@@ -80,18 +92,6 @@ ignore = ["{name}"]
 "#
     )?;
     Ok(())
-}
-
-#[cfg(test)]
-fn cargo_unmaintained(dir: &Path) -> Command {
-    #[cfg_attr(dylint_lib = "general", allow(unnecessary_conversion_for_trait))]
-    // smoelius: `Command::new(cargo_bin!(..))` because this function's return type is
-    // `std::process::Command`, not `assert_cmd::Command`.
-    let mut command = Command::new(cargo::cargo_bin!("cargo-unmaintained"));
-    command
-        .args(["unmaintained", "--fail-fast"])
-        .current_dir(dir);
-    command
 }
 
 #[cfg(not(windows))]

--- a/tests/rustsec_advisories.stdout
+++ b/tests/rustsec_advisories.stdout
@@ -227,17 +227,17 @@ mmap...found
 chrono-english...recently updated
 conrod_core...found
 conrod...found
-gdkwayland...found
-gdkwayland-sys...found
-gdk...found
-atk...found
-gdkx11-sys...found
-gtk...found
-atk-sys...found
-gdkx11...found
-gdk-sys...found
-gtk3-macros...found
-gtk-sys...found
+gdkwayland...recently updated
+gdkwayland-sys...recently updated
+gdk...recently updated
+atk...recently updated
+gdkx11-sys...recently updated
+gtk...recently updated
+atk-sys...recently updated
+gdkx11...recently updated
+gdk-sys...recently updated
+gtk3-macros...recently updated
+gtk-sys...recently updated
 gtk-layer-shell...found
 gtk-layer-shell-sys...found
 get-size...not found
@@ -250,7 +250,7 @@ rustc-serialize...found
 registry...found
 surf...found
 tsify-next...recently updated
-async-std...recently updated
+async-std...found
 adler...found
 fxhash...not found
 custom_derive...found
@@ -396,10 +396,20 @@ not found - leaf (6)
     unic-common               https://rustsec.org/advisories/RUSTSEC-2025-0080.html
     number_prefix             https://rustsec.org/advisories/RUSTSEC-2025-0119.html
     bare-metal                https://rustsec.org/advisories/RUSTSEC-2026-0110.html
-not found - recently-updated (6)
+not found - recently-updated (16)
     chrono-english            https://rustsec.org/advisories/RUSTSEC-2024-0395.html
+    gdkwayland                https://rustsec.org/advisories/RUSTSEC-2024-0410.html
+    gdkwayland-sys            https://rustsec.org/advisories/RUSTSEC-2024-0411.html
+    gdk                       https://rustsec.org/advisories/RUSTSEC-2024-0412.html
+    atk                       https://rustsec.org/advisories/RUSTSEC-2024-0413.html
+    gdkx11-sys                https://rustsec.org/advisories/RUSTSEC-2024-0414.html
+    gtk                       https://rustsec.org/advisories/RUSTSEC-2024-0415.html
+    atk-sys                   https://rustsec.org/advisories/RUSTSEC-2024-0416.html
+    gdkx11                    https://rustsec.org/advisories/RUSTSEC-2024-0417.html
+    gdk-sys                   https://rustsec.org/advisories/RUSTSEC-2024-0418.html
+    gtk3-macros               https://rustsec.org/advisories/RUSTSEC-2024-0419.html
+    gtk-sys                   https://rustsec.org/advisories/RUSTSEC-2024-0420.html
     tsify-next                https://rustsec.org/advisories/RUSTSEC-2025-0048.html
-    async-std                 https://rustsec.org/advisories/RUSTSEC-2025-0052.html
     google-apis-common        https://rustsec.org/advisories/RUSTSEC-2025-0066.html
     unic-cli                  https://rustsec.org/advisories/RUSTSEC-2025-0087.html
     pqcrypto-internals        https://rustsec.org/advisories/RUSTSEC-2026-0163.html
@@ -462,7 +472,7 @@ not found - other (58)
     ttf-parser                https://rustsec.org/advisories/RUSTSEC-2026-0192.html
     gumdrop                   https://rustsec.org/advisories/RUSTSEC-2026-0214.html
     smallstr                  https://rustsec.org/advisories/RUSTSEC-2026-0215.html
-found (160)
+found (150)
     lz4-compress              https://rustsec.org/advisories/RUSTSEC-2017-0007.html
     tempdir                   https://rustsec.org/advisories/RUSTSEC-2018-0017.html
     boxfnonce                 https://rustsec.org/advisories/RUSTSEC-2019-0040.html
@@ -551,17 +561,6 @@ found (160)
     mmap                      https://rustsec.org/advisories/RUSTSEC-2024-0394.html
     conrod_core               https://rustsec.org/advisories/RUSTSEC-2024-0396.html
     conrod                    https://rustsec.org/advisories/RUSTSEC-2024-0397.html
-    gdkwayland                https://rustsec.org/advisories/RUSTSEC-2024-0410.html
-    gdkwayland-sys            https://rustsec.org/advisories/RUSTSEC-2024-0411.html
-    gdk                       https://rustsec.org/advisories/RUSTSEC-2024-0412.html
-    atk                       https://rustsec.org/advisories/RUSTSEC-2024-0413.html
-    gdkx11-sys                https://rustsec.org/advisories/RUSTSEC-2024-0414.html
-    gtk                       https://rustsec.org/advisories/RUSTSEC-2024-0415.html
-    atk-sys                   https://rustsec.org/advisories/RUSTSEC-2024-0416.html
-    gdkx11                    https://rustsec.org/advisories/RUSTSEC-2024-0417.html
-    gdk-sys                   https://rustsec.org/advisories/RUSTSEC-2024-0418.html
-    gtk3-macros               https://rustsec.org/advisories/RUSTSEC-2024-0419.html
-    gtk-sys                   https://rustsec.org/advisories/RUSTSEC-2024-0420.html
     gtk-layer-shell           https://rustsec.org/advisories/RUSTSEC-2024-0422.html
     gtk-layer-shell-sys       https://rustsec.org/advisories/RUSTSEC-2024-0423.html
     get-size-derive           https://rustsec.org/advisories/RUSTSEC-2024-0427.html
@@ -572,6 +571,7 @@ found (160)
     rustc-serialize           https://rustsec.org/advisories/RUSTSEC-2025-0025.html
     registry                  https://rustsec.org/advisories/RUSTSEC-2025-0026.html
     surf                      https://rustsec.org/advisories/RUSTSEC-2025-0036.html
+    async-std                 https://rustsec.org/advisories/RUSTSEC-2025-0052.html
     adler                     https://rustsec.org/advisories/RUSTSEC-2025-0056.html
     custom_derive             https://rustsec.org/advisories/RUSTSEC-2025-0058.html
     servo-fontconfig          https://rustsec.org/advisories/RUSTSEC-2025-0059.html
@@ -624,10 +624,10 @@ found (160)
     im-rc                     https://rustsec.org/advisories/RUSTSEC-2026-0250.html
     sized-chunks              https://rustsec.org/advisories/RUSTSEC-2026-0251.html
 ---
-As of 2026-08-12, the RustSec Advisory Database contains 244 active advisories for unmaintained packages. Using the above conditions, `cargo-unmaintained` automatically identifies 160 (65%) of them. These results can be reproduced by running the [`rustsec_advisories`] example within this repository.
+As of 2026-08-17, the RustSec Advisory Database contains 244 active advisories for unmaintained packages. Using the above conditions, `cargo-unmaintained` automatically identifies 150 (61%) of them. These results can be reproduced by running the [`rustsec_advisories`] example within this repository.
 ---
-- Of the 84 packages in the RustSec Advisory Database _not_ identified by `cargo-unmaintained`:
+- Of the 94 packages in the RustSec Advisory Database _not_ identified by `cargo-unmaintained`:
   - 14 do not build
   - 6 are existent, unarchived leaves
-  - 6 were updated within the past 365 days
+  - 16 were updated within the past 365 days
   - 58 were not identified for other reasons


### PR DESCRIPTION
Claude-generated summary of its changes to src/lib.rs:

### Summary

Reordered functions in `src/lib.rs` to satisfy Dylint’s `non_topologically_sorted_functions` lint.

The new layout:

- Keeps callers before module-local callees.
- Keeps the `unmaintained` helper functions—`latest_version_is_unmaintained`, `metadata_command`, `is_unmaintained_package`, and `newer_version_is_available`—close together.
- Preserves the existing `latest_commit_age` through `clone_repository` call sequence.
- Places `general_status` and `outdated_deps` after `clone_repository` as required.

No function bodies, attributes, or behavior were changed.

### Validation

- `cargo dylint --all`
- `cargo dylint --all -- --all-targets`
- `cargo fmt --check`
- `cargo test --lib`
- `git diff --check`