### PR TITLE
Eliminate use of `group-runner`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
     env:
       RUST_BACKTRACE: 1
       GIT_LFS_SKIP_SMUDGE: 1
-      GROUP_RUNNER: target.'cfg(all())'.runner = 'group-runner'
 
     steps:
       - uses: actions/checkout@v7
@@ -95,7 +94,6 @@ jobs:
       - name: Install general tools
         run: |
           cargo install cargo-nested             || true
-          cargo install group-runner             || true
 
       - name: Enable verbose logging
         if: ${{ runner.debug == 1 }}
@@ -127,7 +125,7 @@ jobs:
         run: cargo build $FEATURES --workspace
 
       - name: Test
-        run: cargo test --config "$GROUP_RUNNER" $FEATURES --test ${{ matrix.test }}
+        run: cargo test $FEATURES --test ${{ matrix.test }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
Since each test [now gets its own job](https://github.com/trailofbits/cargo-unmaintained/pull/836), use of `group-runner` seems unnecessary.